### PR TITLE
autopush artifacts test

### DIFF
--- a/Source/engine/animationinfo.cpp
+++ b/Source/engine/animationinfo.cpp
@@ -74,7 +74,7 @@ float AnimationInfo::GetAnimationProgress() const
 	return animationFraction;
 }
 
-void AnimationInfo::SetNewAnimation(std::optional<CelSprite> celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/, float previewShownGameTickFragments /*= 0.F*/)
+void AnimationInfo::SetNewAnimation(OptionalCelSprite celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags /*= AnimationDistributionFlags::None*/, int numSkippedFrames /*= 0*/, int distributeFramesBeforeFrame /*= 0*/, float previewShownGameTickFragments /*= 0.F*/)
 {
 	if ((flags & AnimationDistributionFlags::RepeatedAction) == AnimationDistributionFlags::RepeatedAction && distributeFramesBeforeFrame != 0 && NumberOfFrames == numberOfFrames && CurrentFrame + 1 >= distributeFramesBeforeFrame && CurrentFrame != NumberOfFrames - 1) {
 		// We showed the same Animation (for example a melee attack) before but truncated the Animation.
@@ -167,7 +167,7 @@ void AnimationInfo::SetNewAnimation(std::optional<CelSprite> celSprite, int numb
 	}
 }
 
-void AnimationInfo::ChangeAnimationData(std::optional<CelSprite> celSprite, int numberOfFrames, int ticksPerFrame)
+void AnimationInfo::ChangeAnimationData(OptionalCelSprite celSprite, int numberOfFrames, int ticksPerFrame)
 {
 	if (numberOfFrames != NumberOfFrames || ticksPerFrame != TicksPerFrame) {
 		// Ensure that the CurrentFrame is still valid and that we disable ADL cause the calculcated values (for example TickModifier) could be wrong

--- a/Source/engine/animationinfo.h
+++ b/Source/engine/animationinfo.h
@@ -40,7 +40,7 @@ public:
 	/**
 	 * @brief Animation sprite
 	 */
-	std::optional<CelSprite> celSprite;
+	OptionalCelSprite celSprite;
 	/**
 	 * @brief How many game ticks are needed to advance one Animation Frame
 	 */
@@ -83,7 +83,7 @@ public:
 	 * @param distributeFramesBeforeFrame Distribute the numSkippedFrames only before this frame
 	 * @param previewShownGameTickFragments Defines how long (in game ticks fraction) the preview animation was shown
 	 */
-	void SetNewAnimation(std::optional<CelSprite> celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0, float previewShownGameTickFragments = 0.F);
+	void SetNewAnimation(OptionalCelSprite celSprite, int numberOfFrames, int ticksPerFrame, AnimationDistributionFlags flags = AnimationDistributionFlags::None, int numSkippedFrames = 0, int distributeFramesBeforeFrame = 0, float previewShownGameTickFragments = 0.F);
 
 	/**
 	 * @brief Changes the Animation Data on-the-fly. This is needed if a animation is currently in progress and the player changes his gear.
@@ -91,7 +91,7 @@ public:
 	 * @param numberOfFrames Number of Frames in Animation
 	 * @param ticksPerFrame How many game ticks are needed to advance one Animation Frame
 	 */
-	void ChangeAnimationData(std::optional<CelSprite> celSprite, int numberOfFrames, int ticksPerFrame);
+	void ChangeAnimationData(OptionalCelSprite celSprite, int numberOfFrames, int ticksPerFrame);
 
 	/**
 	 * @brief Process the Animation for a game tick (for example advances the frame)

--- a/Source/engine/render/scrollrt.cpp
+++ b/Source/engine/render/scrollrt.cpp
@@ -515,7 +515,7 @@ void DrawPlayer(const Surface &out, int pnum, Point tilePosition, Point targetBu
 
 	Player &player = Players[pnum];
 
-	std::optional<CelSprite> sprite = player.AnimInfo.celSprite;
+	OptionalCelSprite sprite = player.AnimInfo.celSprite;
 	int nCel = player.AnimInfo.GetFrameToUseForRendering();
 
 	if (player.previewCelSprite) {
@@ -719,7 +719,7 @@ void DrawItem(const Surface &out, Point tilePosition, Point targetBufferPosition
 	if (item._iPostDraw == pre)
 		return;
 
-	std::optional<CelSprite> cel = item.AnimInfo.celSprite;
+	OptionalCelSprite cel = item.AnimInfo.celSprite;
 	if (!cel) {
 		Log("Draw Item \"{}\" 1: NULL CelSprite", item._iIName);
 		return;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -4582,7 +4582,7 @@ void Item::setNewAnimation(bool showAnimation)
 {
 	int it = ItemCAnimTbl[_iCurs];
 	int numberOfFrames = ItemAnimLs[it];
-	auto celSprite = itemanims[it] ? std::optional<CelSprite> { *itemanims[it] } : std::nullopt;
+	auto celSprite = itemanims[it] ? OptionalCelSprite { *itemanims[it] } : std::nullopt;
 	if (_iCurs != ICURS_MAGIC_ROCK)
 		AnimInfo.SetNewAnimation(celSprite, numberOfFrames, 1, AnimationDistributionFlags::ProcessAnimationPending, 0, numberOfFrames);
 	else

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -133,7 +133,7 @@ enum class LeaderRelation : uint8_t {
 };
 
 struct AnimStruct {
-	[[nodiscard]] std::optional<CelSprite> getCelSpritesForDirection(Direction direction) const
+	[[nodiscard]] OptionalCelSprite getCelSpritesForDirection(Direction direction) const
 	{
 		const byte *spriteData = celSpritesForDirections[static_cast<size_t>(direction)];
 		if (spriteData == nullptr)

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -367,7 +367,7 @@ void StartWalk(int pnum, Displacement vel, Direction dir, bool pmWillBeCalled)
 	StartWalkAnimation(player, dir, pmWillBeCalled);
 }
 
-void SetPlayerGPtrs(const char *path, std::unique_ptr<byte[]> &data, std::array<std::optional<CelSprite>, 8> &anim, int width)
+void SetPlayerGPtrs(const char *path, std::unique_ptr<byte[]> &data, std::array<OptionalCelSprite, 8> &anim, int width)
 {
 	data = nullptr;
 	data = LoadFileInMem(path);
@@ -2164,7 +2164,7 @@ void Player::UpdatePreviewCelSprite(_cmd_id cmdId, Point point, uint16_t wParam1
 		return;
 
 	LoadPlrGFX(*this, *graphic);
-	std::optional<CelSprite> celSprites = AnimationData[static_cast<size_t>(*graphic)].GetCelSpritesForDirection(dir);
+	OptionalCelSprite celSprites = AnimationData[static_cast<size_t>(*graphic)].GetCelSpritesForDirection(dir);
 	if (celSprites && previewCelSprite != celSprites) {
 		previewCelSprite = celSprites;
 		progressToNextGameTickWhenPreviewWasSet = gfProgressToNextGameTick;
@@ -2319,7 +2319,7 @@ void NewPlrAnim(Player &player, player_graphic graphic, Direction dir, int numbe
 {
 	LoadPlrGFX(player, graphic);
 
-	std::optional<CelSprite> celSprite = player.AnimationData[static_cast<size_t>(graphic)].GetCelSpritesForDirection(dir);
+	OptionalCelSprite celSprite = player.AnimationData[static_cast<size_t>(graphic)].GetCelSpritesForDirection(dir);
 
 	float previewShownGameTickFragments = 0.F;
 	if (celSprite == player.previewCelSprite && !player.IsWalking())

--- a/Source/player.h
+++ b/Source/player.h
@@ -196,14 +196,14 @@ struct PlayerAnimationData {
 	/**
 	 * @brief CelSprites for the different directions
 	 */
-	std::array<std::optional<CelSprite>, 8> CelSpritesForDirections;
+	std::array<OptionalCelSprite, 8> CelSpritesForDirections;
 	/**
 	 * @brief Raw Data (binary) of the CL2 file.
 	 *        Is referenced from CelSprite in celSpritesForDirections
 	 */
 	std::unique_ptr<byte[]> RawData;
 
-	[[nodiscard]] std::optional<CelSprite> GetCelSpritesForDirection(Direction direction) const
+	[[nodiscard]] OptionalCelSprite GetCelSpritesForDirection(Direction direction) const
 	{
 		return CelSpritesForDirections[static_cast<size_t>(direction)];
 	}
@@ -234,7 +234,7 @@ struct Player {
 	/**
 	 * @brief Contains a optional preview CelSprite that is displayed until the current command is handled by the game logic
 	 */
-	std::optional<CelSprite> previewCelSprite;
+	OptionalCelSprite previewCelSprite;
 	/**
 	 * @brief Contains the progress to next game tick when previewCelSprite was set
 	 */

--- a/Source/utils/stdcompat/optional.hpp
+++ b/Source/utils/stdcompat/optional.hpp
@@ -7,6 +7,7 @@
 #include <experimental/optional> // IWYU pragma: export
 #define optional experimental::optional
 #define nullopt experimental::nullopt
+#define nullopt_t experimental::nullopt_t
 #else
 #error "Missing support for <optional> or <experimental/optional>"
 #endif


### PR DESCRIPTION
`CelSprite` data pointer can never be `nullptr`.

We implement a smaller `optional` for it by taking advantage of that.