### PR TITLE
Adding required package for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ sudo apt-get install cmake g++ libsdl2-mixer-dev libsdl2-ttf-dev libsodium-dev
 ```
 ### Installing dependencies on Fedora
 ```
-sudo dnf install cmake glibc-devel SDL2-devel SDL2_ttf-devel SDL2_mixer-devel libsodium-devel libasan libubsan
+sudo dnf install cmake glibc-devel SDL2-devel SDL2_ttf-devel SDL2_mixer-devel libsodium-devel libasan libubsan libstdc++-static
 ```
 ### Compiling
 ```


### PR DESCRIPTION
The "libstdc++-static" package is required to avoid `/usr/bin/ld: cannot find -lstdc++`